### PR TITLE
docs: update SDK-Js documentation to refer correct name

### DIFF
--- a/sdks.mdx
+++ b/sdks.mdx
@@ -96,7 +96,7 @@ npm install @trufnetwork/sdk-js
 _Example Usage:_
 
 ```javascript
-import { NodeTSNClient, StreamId } from "@trufnetwork/sdk-js";
+import { NodeTNClient, StreamId } from "@trufnetwork/sdk-js";
 
 // Create a wallet
 const wallet = new Wallet(
@@ -104,7 +104,7 @@ const wallet = new Wallet(
 );
 
 // Initialize client
-const client = new NodeTSNClient({
+const client = new NodeTNClient({
 	endpoint: "https://staging.tsn.truflation.com",
     signerInfo: {
         address: wallet.address,


### PR DESCRIPTION
This pull request includes a small change to the `sdks.mdx` file. The change corrects the import statement and client initialization by renaming `NodeTSNClient` to `NodeTNClient`.

* [`sdks.mdx`](diffhunk://#diff-5f8f76ca9790fc726facf14cfefce9f857bcae827bef9f1a0212056b6eaaf1d7L99-R107): Corrected import statement and client initialization from `NodeTSNClient` to `NodeTNClient`.

resolves: https://github.com/trufnetwork/docs/issues/91