### PR TITLE
docs: add Raydium DEX and TRUF on Solana

### DIFF
--- a/token-governance/get-truf-token.mdx
+++ b/token-governance/get-truf-token.mdx
@@ -17,6 +17,7 @@ description: Learn how to acquire TRUF tokens across various exchanges and netwo
 - **[MEXC](https://www.mexc.com/exchange/TRUF_USDT)**
 - **[Gate.io](https://www.gate.io/trade/TRUF_USDT)**
 - **[CoinEx](https://www.coinex.com/en/exchange/truf-usdt)**
+- **[Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=TRUFoUAg3rKEtcFxxeeuVm6Dc4Er55McRXMSgPk3hZ4)**
 
 See the complete list of exchanges on [CoinMarketCap](https://coinmarketcap.com/currencies/truflation/).
 
@@ -47,6 +48,10 @@ Ensure you're interacting with the correct TRUF token by verifying the contract 
 - **Arbitrum:**
   - **Address:** `0xB59c8912c83157a955f9D715E556257F432C35D7`
   - [View on Arbiscan](https://arbiscan.io/address/0xB59c8912c83157a955f9D715E556257F432C35D7)
+
+- **Solana**
+  - **Address:** `TRUFoUAg3rKEtcFxxeeuVm6Dc4Er55McRXMSgPk3hZ4`
+  - [View on Solscan](https://solscan.io/token/TRUFoUAg3rKEtcFxxeeuVm6Dc4Er55McRXMSgPk3hZ4)
 
 ## Learn More
 


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-claim-page/issues/491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the TRUF token guide to include Raydium in the Available Exchanges list for easier discovery and trading.
  * Added a new Solana section detailing the official TRUF mint address with a direct Solscan link for verification and wallet integration.
  * Content enhancements only; no changes to functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->