### PR TITLE
docs: view ai-toolkit with its new MCP server status

### DIFF
--- a/ai-toolkit.mdx
+++ b/ai-toolkit.mdx
@@ -5,33 +5,32 @@ description: "Discover TRUF.NETWORK's vision for AI-powered Web3 development too
 
 ![AI Toolkit](/images/ai-toolkit.png)
 
-> **Note:** The AI Toolkit is currently in development. This page outlines our vision and planned features. Stay tuned for updates!
+> **🚀 Now Live:** Our MCP (Model Context Protocol) Server is now available! Connect AI agents directly to verifiable real-world data using SQL.
 
-> **Join the Waitlist:** Be among the first to access our AI Toolkit. [Sign up now](https://truf.network/ai-toolkit) for early access!
-
-The TRUF.NETWORK AI Toolkit is our vision for empowering developers with AI-driven tools and insights to accelerate Web3 development. This comprehensive toolkit is being designed to help you build, analyze, and deploy smarter crypto applications.
+The TRUF.NETWORK AI Toolkit empowers developers with AI-driven tools and insights to accelerate Web3 development. Our comprehensive toolkit helps you build, analyze, and deploy smarter crypto applications with direct access to verified real-world asset data.
 
 ## Features
 
+### MCP Server
+
+Our Model Context Protocol server connects AI agents directly to verifiable real-world data:
+
+- **Natural Language to SQL**: AI translates plain English queries into SQL
+- **Real-World Asset Data**: Access verified event data for RWAs
+- **Claude Desktop Integration**: Tested and verified with Claude Desktop
+- **MCP Protocol Standard**: Compatible with other MCP-supporting clients
+- **Event-Driven Queries**: Query real-world events and market data instantly
+- **Programmable Truth**: "SQL + AI + real-world data = programmable truth at scale"
+
 ### AI-Powered APIs
 
-A suite of AI-powered APIs that will allow you to integrate advanced AI features into your applications, specifically optimized for crypto and Web3 use cases.
+A suite of AI-powered APIs that allow you to integrate advanced AI features into your applications, specifically optimized for crypto and Web3 use cases.
 
 ### Developer SDKs
 
 Straightforward interfaces to help you integrate our AI tools and services into your development workflow.
 
-### Model Context Protocol (MCP)
-
-A standardized framework for connecting AI models and external data sources. Key features include:
-
-- Real-time, bidirectional communication
-- Automatic tool discovery
-- Built-in security and API gateway management
-- Fault isolation capabilities
-- Plug-and-play expansion
-
-### SQL-Powered Calculation Agent
+### SQL-Powered Data Access
 
 Features include:
 
@@ -39,14 +38,16 @@ Features include:
 - Reliable data processing
 - Familiar SQL syntax for easy integration
 - Real-time data analysis
+- Direct access to verified market-moving information
 
 ## Data Access
 
-The toolkit will provide access to:
+The toolkit provides access to:
 
 - 100M+ verified Real-World Asset (RWA) data points
 - 1M+ on-chain price data points and indexes
 - Real-time market data analysis
+- Event-driven data for prediction markets, trading bots, and DeFi applications
 
 ## MCP vs Traditional APIs
 
@@ -60,9 +61,16 @@ The toolkit will provide access to:
 
 ## Getting Started
 
-To stay updated on the AI Toolkit development:
+### MCP Server Integration
 
-1. [Join our waitlist](https://truf.network/ai-toolkit) for early access
-2. Follow our development updates
+1. **Review Documentation**: Check out our [MCP Server documentation on GitHub](https://github.com/trufnetwork/node/blob/main/docs/mcp-server.md) for detailed setup instructions
+2. **Configure Claude Desktop**: Currently tested and supported with Claude Desktop (configuration instructions in GitHub docs)
+3. **Start Querying**: Use plain English to query real-world asset data - Claude will translate to SQL automatically
+4. **Build Applications**: Integrate the MCP server into your prediction markets, trading bots, or DeFi products
+
+### Additional Resources
+
+1. Read our [launch blog post](https://blog.truf.network/mcp-is-live-ai-sql-and-real-world-assets-finally-connect-on-chain/) for implementation examples
+2. Follow our development updates for new features
 3. Participate in our community discussions
 4. Share your feedback and use cases

--- a/ai-toolkit.mdx
+++ b/ai-toolkit.mdx
@@ -70,7 +70,8 @@ The toolkit provides access to:
 
 ### Additional Resources
 
-1. Read our [launch blog post](https://blog.truf.network/mcp-is-live-ai-sql-and-real-world-assets-finally-connect-on-chain/) for implementation examples
-2. Follow our development updates for new features
-3. Participate in our community discussions
-4. Share your feedback and use cases
+1. Read our [MCP technical overview](https://truf.network/updates/mcp) for implementation examples and use cases
+2. Check out our [launch announcement](https://blog.truf.network/mcp-is-live-ai-sql-and-real-world-assets-finally-connect-on-chain) for feature overview
+3. Follow our development updates for new features
+4. Participate in our community discussions
+5. Share your feedback and use cases


### PR DESCRIPTION
Update AI Toolkit documentation to reflect current MCP server status

- Remove development notices and waitlist references
- Add MCP server features and capabilities section
- Revise getting started guide with practical implementation steps

resolves: https://github.com/trufnetwork/truf-network/issues/1176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Announced live MCP Server and removed waitlist messaging; intro now emphasizes direct access to verified real-world asset data.
  * Renamed AI-Powered APIs → MCP Server and consolidated SDK items under that section.
  * Renamed SQL-Powered Calculation Agent → SQL-Powered Data Access; Data Access copy updated to include event-driven data use cases.
  * Reworked Getting Started into a 4-step MCP Server Integration; added Additional Resources and updated docs/blog links.
  * Minor copy and structural refinements; comparison table unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->